### PR TITLE
build(vercel): use prisma migrate deploy for all vercel environments

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "dev": "next dev --turbo",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,mdx}\" --cache",
     "format:write": "prettier --write \"**/*.{ts,tsx,js,jsx,mdx}\" --cache",
-    "vercel-build": "prisma generate && if [ \"$VERCEL_ENV\" = \"production\" ]; then npx prisma migrate deploy; elif [ \"$VERCEL_ENV\" = \"preview\" ]; then npx prisma db push; fi && next build",
+    "vercel-build": "prisma generate && npx prisma migrate deploy && next build",
     "postinstall": "prisma generate",
     "lint": "next lint",
     "lint:fix": "next lint --fix",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Simplified the build process to always run database migrations before building the application, regardless of environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->